### PR TITLE
check for newer data in files to be consolidated

### DIFF
--- a/default.php
+++ b/default.php
@@ -422,37 +422,36 @@ class Consolidate extends Gdn_Plugin {
    protected function _Consolidate($Files, $Suffix, $Prefix = '') { 
       $Token = $Prefix.md5(serialize($Files)).$Suffix;
       $CacheFile = PATH_CACHE."/Consolidate/$Token";
-      if(in_array($Token,$this->ChunkedFiles))
+      $mtime = function($File) { return filemtime(PATH_ROOT.DS.$File['href']); };
+      if(in_array($Token,$this->ChunkedFiles) && max(array_map($mtime, $Files)) < filemtime($CacheFile))
         return $Token;
-      if (!file_exists($CacheFile)) {
-          $ConsolidateFile = '';
-          $PathRootParts = split(DS,PATH_ROOT);
-          $WebRootParts = split(DS,$this->WebRoot);
-          $Base = join(DS,array_slice($PathRootParts,0,-count($WebRootParts)));
-          foreach($Files As $File){
-              $ConsolidateFile .= "/*\n";
-              $ConsolidateFile .= "* Consolidate '{$File['fullhref']}'\n";
-              $ConsolidateFile .= "*/\n\n";
-              $OriginalFile = PATH_ROOT.DS.$File['href'];
-              $FileStr = file_get_contents($OriginalFile);
-              if($FileStr && strtolower($Suffix)=='.css'){
-                  $FileStr = Minify_CSS_UriRewriter::rewrite($FileStr,dirname($Base.DS.$this->WebRoot.DS.$File['href']),$Base);
-                  $FileStr = Minify_CSS_Compressor::process($FileStr);
-              }
-              $ConsolidateFile .= trim($FileStr);
-              if($FileStr && strtolower($Suffix)=='.js'){
-                  if(substr($ConsolidateFile,-1)!=';')
-                    $ConsolidateFile .= ";";
-              }
-              $ConsolidateFile .= "\n\n";
-          }
-         if (!file_exists(dirname($CacheFile)))
-            mkdir(dirname($CacheFile), 0777, TRUE);
-         file_put_contents($CacheFile, $ConsolidateFile);
+      $ConsolidateFile = '';
+      $PathRootParts = split(DS,PATH_ROOT);
+      $WebRootParts = split(DS,$this->WebRoot);
+      $Base = join(DS,array_slice($PathRootParts,0,-count($WebRootParts)));
+      foreach($Files As $File){
+         $ConsolidateFile .= "/*\n";
+         $ConsolidateFile .= "* Consolidate '{$File['fullhref']}'\n";
+         $ConsolidateFile .= "*/\n\n";
+         $OriginalFile = PATH_ROOT.DS.$File['href'];
+         $FileStr = file_get_contents($OriginalFile);
+         if($FileStr && strtolower($Suffix)=='.css'){
+            $FileStr = Minify_CSS_UriRewriter::rewrite($FileStr,dirname($Base.DS.$this->WebRoot.DS.$File['href']),$Base);
+            $FileStr = Minify_CSS_Compressor::process($FileStr);
+         }
+         $ConsolidateFile .= trim($FileStr);
+         if($FileStr && strtolower($Suffix)=='.js'){
+            if(substr($ConsolidateFile,-1)!=';')
+              $ConsolidateFile .= ";";
+         }
+         $ConsolidateFile .= "\n\n";
       }
+      if (!file_exists(dirname($CacheFile)))
+         mkdir(dirname($CacheFile), 0777, TRUE);
+      file_put_contents($CacheFile, $ConsolidateFile);
       if(!in_array($Token,$this->ChunkedFiles))
           $this->ChunkedFiles[] = $Token;
-      
+
       return $Token;
    }
    


### PR DESCRIPTION
If you are editing css or js files, you have to clear the consolidate cache in order to apply the changed content. Therefore, this pull request introduces a check, if there is a file which was changed after the consolidated file was created. This is done by gathering the `filemtime` of all files of that chunk.

The code change is very small (4 lines of code) and the costs at runtime should be very low, since the `filemtime` will be cached by the operating system. However, the convenience increases clearly.

Beside, I've tried to unify the indentation in this code snippet. However, the whole file uses many different indentation sizes in different parts. This should be reformatted.